### PR TITLE
Set right entry point, fix #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jspdf-invoice-template",
   "version": "1.3.1",
   "description": "PDF template created for invoice with optional parameters. Using jsPDF library.",
-  "main": "index.js",
+  "main": "./dist/index.js",
   "scripts": {
     "build": "webpack --mode production",
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
I noticed that when importing the lib, it was importing directly the source code instead of the compiled and polyfilled code generated by babel, located under the `./dist` folder

The fix is changing the entry point of this lib from `./index.js` to `./dist/index.js`

I had this issue (#5) and doing this change fixed the lib immediately for me