### PR TITLE
Fix type of additionalRows

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -149,16 +149,14 @@ declare function jsPDFInvoiceTemplate(props: {
         table?: any;
         invDescLabel?: string;
         invDesc?: string;
-        additionalRows?: [
-            {
+        additionalRows?: {
                 col1?: string;
                 col2?: string;
                 col3?: string;
                 style?: {
                     fontSize?: number;
                 };
-            }
-        ];
+            }[];
     };
     footer?: {
         text?: string;

--- a/src/index.js
+++ b/src/index.js
@@ -71,14 +71,14 @@ export { OutputType, jsPDF };
  *       table?: any,
  *       invDescLabel?: string,
  *       invDesc?: string,
- *       additionalRows?: [{
+ *       additionalRows?: {
  *           col1?: string,
  *           col2?: string,
  *           col3?: string,
  *           style?: {
  *               fontSize?: number
  *           }
- *       }],
+ *       }[],
  *   },
  *   footer?: {
  *       text?: string,


### PR DESCRIPTION
Basically `[ {col1: ...} ]` ends up being a tuple type, which in this case is an array with a single element https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types

What we actually seem to want is `{col1: ...}[]`, which is indeed an array with an arbitrary number of elements.

(I edited the code on the Github web interface, so I apologize if I messed up anywhere.)